### PR TITLE
SHARE-412 Store JWT on client side

### DIFF
--- a/catroweb.yaml
+++ b/catroweb.yaml
@@ -82,6 +82,35 @@ paths:
           $ref: '#/components/responses/NotAcceptable'
         '415':
           $ref: '#/components/responses/UnsupportedMediaType'
+  /authentication/refresh:
+    post:
+      security:
+        - PandaAuth: []
+      tags:
+        - Authentication
+      summary: Refresh token
+      description: Returns a new JWT token with help of the refresh token
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JWTResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/InvalidRefreshToken'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
   /authentication/oauth:
     post:
       tags:
@@ -111,6 +140,35 @@ paths:
           $ref: '#/components/responses/UnsupportedMediaType'
         422:
           description: Unprocessable Entity
+  /authentication/logout:
+    post:
+      security:
+        - PandaAuth: []
+      tags:
+        - Authentication
+      summary: Expires refresh token
+      description: Sets refresh token to expired
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshRequest'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JWTResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/InvalidRefreshToken'
+        '406':
+          $ref: '#/components/responses/NotAcceptable'
+        '415':
+          $ref: '#/components/responses/UnsupportedMediaType'
 
   ##############################################
   # Utility
@@ -745,6 +803,9 @@ components:
     InvalidCredentials:
       description: Invalid credentials
 
+    InvalidRefreshToken:
+      description: Refresh Token expired | Refresh Token has been used more than once (single use)
+
     NotAcceptable:
       description: Not acceptable - client must accept application/json as content type
 
@@ -1016,6 +1077,12 @@ components:
           type: string
           example: google
           description: OAuth provider
+    RefreshRequest:
+      type: object
+      properties:
+        refresh_token:
+          type: string
+          example: xxxxx.yyyyy.zzzzz
 
     ## Response
 
@@ -1023,6 +1090,9 @@ components:
       type: object
       properties:
         token:
+          type: string
+          example: xxxxx.yyyyy.zzzzz
+        refresh_token:
           type: string
           example: xxxxx.yyyyy.zzzzz
 


### PR DESCRIPTION
Authentication now returns also the refresh token for using api calls in the webview.
Added refresh and logout route.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) of this repository.

- [x] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [x] Choose the proper base branch (*develop*)
- [x] Confirm that the changes follow the project’s coding guidelines
- [x] Verify that the changes generate no warnings and errors 
- [x] Verify to commit no other files than the intentionally changed ones
- [x] Include reasonable and readable tests verifying the added or changed behavior
- [x] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [x] Perform a self-review of the changes
- [x] Stick to the project’s git workflow (rebase and squash your commits)
- [x] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
Added refresh token for working with the Api in the webview.
/authentication now returns the jwt and the refresh token. If the jwt expires now /authentication/refresh can be called to get a new jwt and refresh token and so on. authentication/logout should expire the refresh token, so that the a new normal authentication has to happen to authenticate.

### Tests - additional information
-