### PR TITLE
SHARE-513 Extension of Survey Endpoint with flavor and flatform

### DIFF
--- a/Api/UtilityApiInterface.php
+++ b/Api/UtilityApiInterface.php
@@ -56,9 +56,10 @@ interface UtilityApiInterface
    * Get survey link for given language code.
    *
    * @param string $lang_code       2 letter Language-Code is based on ISO693-1 (e.g. German &#x3D; de, English &#x3D; en, Russian &#x3D; ru) (required)
-   * @param string $flavor          (optional, default to '')
+   * @param string $flavor          (optional, default to 'pocketcode')
+   * @param string $platform        (optional, default to 'Android')
    * @param int    &$responseCode   The HTTP Response Code
    * @param array  $responseHeaders Additional HTTP headers to return with the response ()
    */
-  public function surveyLangCodeGet(string $lang_code, string $flavor, int &$responseCode, array &$responseHeaders): array|object|null;
+  public function surveyLangCodeGet(string $lang_code, string $flavor, string $platform, int &$responseCode, array &$responseHeaders): array|object|null;
 }

--- a/Controller/UtilityController.php
+++ b/Controller/UtilityController.php
@@ -125,6 +125,14 @@ class UtilityController extends Controller
 
     // Read out all input parameter values into variables
     $flavor = $request->query->get('flavor', '');
+    if (is_null($flavor) || trim($flavor) == '') {
+      $flavor = 'pocketcode';
+    }
+
+    $platform = $request->query->get('platform', '');
+    if (is_null($platform) || trim($platform) == '') {
+      $platform = 'Android';
+    }
 
     // Use the default value if no value was provided
 
@@ -132,6 +140,7 @@ class UtilityController extends Controller
     try {
       $lang_code = $this->deserialize($lang_code, 'string', 'string');
       $flavor = $this->deserialize($flavor, 'string', 'string');
+      $platform = $this->deserialize($platform, 'string', 'string');
     } catch (SerializerRuntimeException $exception) {
       return $this->createBadRequestResponse($exception->getMessage());
     }
@@ -150,6 +159,13 @@ class UtilityController extends Controller
     if ($response instanceof Response) {
       return $response;
     }
+    $asserts = [];
+    $asserts[] = new Assert\Type('string');
+    $response = $this->validate($platform, $asserts);
+    if ($response instanceof Response) {
+      return $response;
+    }
+    
 
     try {
       $handler = $this->getApiHandler();
@@ -158,7 +174,7 @@ class UtilityController extends Controller
       $responseCode = 200;
       $responseHeaders = [];
 
-      $result = $handler->surveyLangCodeGet($lang_code, $flavor, $responseCode, $responseHeaders);
+      $result = $handler->surveyLangCodeGet($lang_code, $flavor, $platform, $responseCode, $responseHeaders);
 
       // Find default response message
       $message = '';

--- a/Resources/docs/Api/UtilityApiInterface.md
+++ b/Resources/docs/Api/UtilityApiInterface.md
@@ -104,7 +104,8 @@ class UtilityApi implements UtilityApiInterface
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **lang_code** | **string**| 2 letter Language-Code is based on ISO693-1 (e.g. German &#x3D; de, English &#x3D; en, Russian &#x3D; ru) |
- **flavor** | **string**|  | [optional] [default to &#39;&#39;]
+ **flavor** | **string**|  | [optional] [default to &#39;pocketcode&#39;]
+ **platform** | **string**|  | [optional] [default to &#39;Android&#39;]
 
 ### Return type
 

--- a/catroweb.yaml
+++ b/catroweb.yaml
@@ -224,6 +224,28 @@ paths:
           required: true
           description: "2 letter Language-Code is based on ISO693-1 (e.g. German = de, English = en, Russian = ru)"
         - $ref: '#/components/parameters/Flavor'
+        
+        - in: query
+          name: flavor
+          schema:
+            type: string
+            example: "pocketcode"
+          required: false
+          description: "Indication what platform should be used (pocketcode, luna, embroidery, etc.)"
+        - $ref: '#/components/parameters/Flavor'
+
+        - in: query
+          name: platform
+          schema:
+            type: string
+            example: "ios"
+          required: false
+          description: "Indication what platform should be used (ios, android)"
+          enum:
+              - ""
+              - "android"
+              - "ios"
+        - $ref: '#/components/parameters/Platform'
       tags:
         - Utility
       summary: "Get survey link for given language code."


### PR DESCRIPTION
It is requested that the surveys can be configured with two extra parameters, namely flavor and platform and therefore the API Endpoint has to be extended as well.

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`