### PR TITLE
SHARE-555 child restriction

### DIFF
--- a/catroweb.yaml
+++ b/catroweb.yaml
@@ -2135,6 +2135,10 @@ components:
           type: number
           example: 0.14381762458251943
           description: "The filesize of the catrobat file in megabytes"
+        not_for_kids:
+          type: number
+          example: 0
+          description: "Indicates whether a project is suitable for kids or not (0 = safe for kids, 1 = not safe for kids, 2 = not safe for kids set by moderator)"
 
     ExtensionsResponse:
       type: array


### PR DESCRIPTION
added new not_for_kids property to ProjectResponse

---
### Your checklist for this pull request
Please review the [contributing guidelines](https://github.com/Catrobat/Catroweb-Symfony/blob/develop/.github/contributing.md) of this repository.

- [ ] Include the name and id of the Jira ticket in the PR’s title eg.: `SHARE-666 The devils ticket`
- [ ] Choose the proper base branch (*develop*)
- [ ] Confirm that the changes follow the project’s coding guidelines
- [ ] Verify that the changes generate no warnings and errors 
- [ ] Verify to commit no other files than the intentionally changed ones
- [ ] Include reasonable and readable tests verifying the added or changed behavior
- [ ] Verify that all tests are passing, if not please state the test cases in the [section](#Tests) below
- [ ] Perform a self-review of the changes
- [ ] Stick to the project’s git workflow (rebase and squash your commits)
- [ ] Verify that your changes do not have any conflicts with the base branch
- [ ] Put your ticket into the `Code Review` section in [Jira](https://jira.catrob.at/)
- [ ] Post a message in the *#catroweb* [Slack channel](https://catrobat.slack.com) and ask for a code reviewer

### Additional Description
`TODO: Add additional information that is not in your commit-message here`

### Tests - additional information
`TODO: add additional information about testruns here`